### PR TITLE
EmailAuth module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@prisma/cli": "^2.17.0",
     "@prisma/client": "2.17.0",
+    "@types/nodemailer": "^6.4.0",
     "apollo-server-koa": "^2.19.2",
     "cross-env": "^7.0.3",
     "crypto": "^1.0.1",
@@ -26,7 +27,8 @@
     "koa-helmet": "^6.0.0",
     "koa-router": "^10.0.0",
     "nexus": "^1.0.0",
-    "nexus-plugin-prisma": "^0.28.0"
+    "nexus-plugin-prisma": "^0.28.0",
+    "nodemailer": "^6.4.18"
   },
   "devDependencies": {
     "@types/joi": "^17.2.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,3 +173,9 @@ model ProjectImage {
     link       String  @db.Text
     order      Int
 }
+
+model EmailAuth {
+    id        Int    @id @default(autoincrement())
+    email     String
+    auth_code String
+}

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -1,8 +1,8 @@
 import * as nodemailer from "nodemailer";
 
 // .env파일에서 정보 가져오기
-const TransporterUser = process.env.NODEMAILER_USER;
-const TransporterPass = process.env.NODEMAILER_PASS;
+const TransporterUser: string = process.env.NODEMAILER_USER;
+const TransporterPass: string = process.env.NODEMAILER_PASS;
 
 const transporter: nodemailer.Transporter = nodemailer.createTransport({
     //이메일 transporter 정보
@@ -31,13 +31,13 @@ export const emailAuth: Function = async (receiver: string) => {
         .sendMail(mailOptions)
         .then((info) => info.messageId)
         .catch((err) => {
-            console.log(err);
+            throw new Error(err);
         });
 };
 
 // 6자리 인증 번호 생성
 const genearteAuthCode: Function = () => {
-    let authCode = Math.floor(Math.random() * 1000000) + 100000;
+    let authCode: number = Math.floor(Math.random() * 1000000) + 100000;
     if (authCode > 1000000) {
         authCode -= 100000;
     }

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -35,10 +35,12 @@ export const sendAuthCode: Function = async (receiver: string) => {
 
     await transporter //메일 보내기
         .sendMail(mailOptions)
-        .then(() => addAuthInfo(receiver, auth_code))
+        .then((info) => info.messageId)
         .catch((err) => {
             throw new Error(err);
         });
+    // 메일 인증 후 DB에 추가
+    addAuthInfo(receiver, auth_code);
 };
 // 인증정보 DB에 추가
 const addAuthInfo: Function = async (user: string, auth_code: string) => {

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -33,14 +33,12 @@ export const sendAuthCode: Function = async (receiver: string) => {
                 <h2>인증번호: ${auth_code}</h2>`,
     };
 
-    await transporter //메일 보내기
-        .sendMail(mailOptions)
-        .then((info) => info.messageId)
-        .catch((err) => {
-            throw new Error(err);
-        });
-    // 메일 인증 후 DB에 추가
-    addAuthInfo(receiver, auth_code);
+    try {
+        await transporter.sendMail(mailOptions); //메일 보내기
+    } catch (err) {
+        throw new Error(err);
+    }
+    await addAuthInfo(receiver, auth_code);
 };
 // 인증정보 DB에 추가
 const addAuthInfo: Function = async (user: string, auth_code: string) => {

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -50,3 +50,38 @@ const addAuthInfo: Function = async (user: string, auth_code: string) => {
         },
     });
 };
+
+//인증 코드 확인
+export const checkAuthCode: Function = async (
+    user: string,
+    auth_code: string
+) => {
+    const prisma = new PrismaClient();
+    const auth_info = await prisma.emailAuth.findFirst({
+        // 인증번호 존재 확인
+        where: {
+            email: user,
+            auth_code: auth_code,
+        },
+        select: {
+            id: true,
+        },
+    });
+    if (auth_info) {
+        //인증 확인되면 삭제
+        deleteAuthCode(auth_info.id);
+        return true;
+    } else {
+        false;
+    }
+};
+
+//인증코드 정보 삭제
+export const deleteAuthCode: Function = async (id: number) => {
+    const prisma = new PrismaClient();
+    await prisma.emailAuth.delete({
+        where: {
+            id: id,
+        },
+    });
+};

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -1,20 +1,23 @@
 import * as nodemailer from "nodemailer";
 
+// .env파일에서 정보 가져오기
 const TransporterUser = process.env.NODEMAILER_USER;
 const TransporterPass = process.env.NODEMAILER_PASS;
 
 const transporter: nodemailer.Transporter = nodemailer.createTransport({
+    //이메일 transporter 정보
     service: "gmail",
     auth: {
-        user: TransporterUser, //env 파일
+        user: TransporterUser,
         pass: TransporterPass,
     },
 });
 
 export const emailAuth: Function = async (receiver: string) => {
-    const authCode: number = genearteAuthCode();
+    const authCode: number = genearteAuthCode(); //인증 번호 생성
 
     const mailOptions: nodemailer.SendMailOptions = {
+        //메일 정보 설정
         from: `Olio development ${TransporterUser}`,
         to: `${receiver}`,
         subject: "Olio 포트폴리오 사이트 - 이메일 인증 요청 메일",
@@ -24,7 +27,7 @@ export const emailAuth: Function = async (receiver: string) => {
                 <h2>인증번호: ${authCode}</h2>`,
     };
 
-    await transporter
+    await transporter //메일 보내기
         .sendMail(mailOptions)
         .then((info) => info.messageId)
         .catch((err) => {
@@ -32,6 +35,7 @@ export const emailAuth: Function = async (receiver: string) => {
         });
 };
 
+// 6자리 인증 번호 생성
 const genearteAuthCode: Function = () => {
     let authCode = Math.floor(Math.random() * 1000000) + 100000;
     if (authCode > 1000000) {

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -1,4 +1,5 @@
 import * as nodemailer from "nodemailer";
+import { PrismaClient } from "@prisma/client";
 
 // .env파일에서 정보 가져오기
 const TransporterUser: string = process.env.NODEMAILER_USER;
@@ -13,10 +14,14 @@ const transporter: nodemailer.Transporter = nodemailer.createTransport({
     },
 });
 
-export const emailAuth: Function = async (receiver: string) => {
+export const sendAuthCode: Function = async (receiver: string) => {
     //사용자의 이메일주소
-    const authCode: number = genearteAuthCode(); //인증 번호 생성
-
+    // 6자리 인증 번호 생성
+    let auth_code: any = Math.floor(Math.random() * 1000000) + 100000;
+    if (auth_code > 1000000) {
+        auth_code -= 100000;
+    }
+    auth_code = auth_code.toString();
     const mailOptions: nodemailer.SendMailOptions = {
         //메일 정보 설정
         from: `Olio development ${TransporterUser}`,
@@ -25,7 +30,7 @@ export const emailAuth: Function = async (receiver: string) => {
         text: `Olio 이메일 인증 요청 메일입니다.`,
         html: `<b>안녕하세요 ${receiver}님, Olio 포트폴리오 사이트 입니다.</b></br>
                 <b>아래 코드를 복사하여 본인 인증코드란에 입력하시기 바랍니다. </b></br>
-                <h2>인증번호: ${authCode}</h2>`,
+                <h2>인증번호: ${auth_code}</h2>`,
     };
 
     await transporter //메일 보내기
@@ -34,13 +39,4 @@ export const emailAuth: Function = async (receiver: string) => {
         .catch((err) => {
             throw new Error(err);
         });
-};
-
-// 6자리 인증 번호 생성
-const genearteAuthCode: Function = () => {
-    let authCode: number = Math.floor(Math.random() * 1000000) + 100000;
-    if (authCode > 1000000) {
-        authCode -= 100000;
-    }
-    return authCode;
 };

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -35,8 +35,18 @@ export const sendAuthCode: Function = async (receiver: string) => {
 
     await transporter //메일 보내기
         .sendMail(mailOptions)
-        .then((info) => info.messageId)
+        .then(() => addAuthInfo(receiver, auth_code))
         .catch((err) => {
             throw new Error(err);
         });
+};
+// 인증정보 DB에 추가
+const addAuthInfo: Function = async (user: string, auth_code: string) => {
+    const prisma = new PrismaClient();
+    await prisma.emailAuth.create({
+        data: {
+            email: user,
+            auth_code: auth_code,
+        },
+    });
 };

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -1,0 +1,41 @@
+import * as nodemailer from "nodemailer";
+
+const TransporterUser = process.env.NODEMAILER_USER;
+const TransporterPass = process.env.NODEMAILER_PASS;
+
+const transporter: nodemailer.Transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+        user: TransporterUser, //env 파일
+        pass: TransporterPass,
+    },
+});
+
+export const emailAuth: Function = async (receiver: string) => {
+    const authCode: number = genearteAuthCode();
+
+    const mailOptions: nodemailer.SendMailOptions = {
+        from: `Olio development ${TransporterUser}`,
+        to: `${receiver}`,
+        subject: "Olio 포트폴리오 사이트 - 이메일 인증 요청 메일",
+        text: `Olio 이메일 인증 요청 메일입니다.`,
+        html: `<b>안녕하세요 ${receiver}님, Olio 포트폴리오 사이트 입니다.</b></br>
+                <b>아래 코드를 복사하여 본인 인증코드란에 입력하시기 바랍니다. </b></br>
+                <h2>인증번호: ${authCode}</h2>`,
+    };
+
+    await transporter
+        .sendMail(mailOptions)
+        .then((info) => info.messageId)
+        .catch((err) => {
+            console.log(err);
+        });
+};
+
+const genearteAuthCode: Function = () => {
+    let authCode = Math.floor(Math.random() * 1000000) + 100000;
+    if (authCode > 1000000) {
+        authCode -= 100000;
+    }
+    return authCode;
+};

--- a/src/util/emailAuth.ts
+++ b/src/util/emailAuth.ts
@@ -14,6 +14,7 @@ const transporter: nodemailer.Transporter = nodemailer.createTransport({
 });
 
 export const emailAuth: Function = async (receiver: string) => {
+    //사용자의 이메일주소
     const authCode: number = genearteAuthCode(); //인증 번호 생성
 
     const mailOptions: nodemailer.SendMailOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.51.tgz#639538575befbcf3d3861f95c41de8e47124d674"
   integrity sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==
 
+"@types/nodemailer@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.0.tgz#d8c039be3ed685c4719a026455555be82c124b74"
+  integrity sha512-KY7bFWB0MahRZvVW4CuW83qcCDny59pJJ0MQ5ifvfcjNwPlIT0vW4uARO4u1gtkYnWdhSvURegecY/tzcukJcA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/qs@*":
   version "6.9.5"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
@@ -1728,6 +1735,11 @@ node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+nodemailer@^6.4.18:
+  version "6.4.18"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.4.18.tgz#2788c85792844fc17befda019031609017f4b9a1"
+  integrity sha512-ht9cXxQ+lTC+t00vkSIpKHIyM4aXIsQ1tcbQCn5IOnxYHi81W2XOaU66EQBFFpbtzLEBTC94gmkbD4mGZQzVpA==
 
 nodemon@^2.0.7:
   version "2.0.7"


### PR DESCRIPTION
- src/util/emailAuth.ts 에 모듈 작성
-  sendAuthCode: 유저 본인임을 확인하는 이메일을 전송 (auth_code는 6자리의 숫자로 구성)
- addAuthinfo: auth_code 생성 후 이메일과 함께 DB 저장
- checkAuthCode: 유저가 코드 입력하여 본인 확인
- deleteAuchCode: checkAuthCode 후 인증코드 레코드 삭제