### PR TITLE
[ADD] timestamp & project and portfolio counts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,8 @@ model User {
     profile_image  String?         @db.Text
     introduction   String?
     entrance_year  Int
-    createdAt      DateTime        @default(now())
+    created_at     DateTime        @default(now())
+    updated_at     DateTime        @default(now())
     Portfolio      Portfolio?
     Project        Project[]
     LikedPortfolio PortfolioLike[]
@@ -36,6 +37,10 @@ enum School {
 model Portfolio {
     owner                User                   @relation(fields: [id], references: [id])
     id                   Int                    @id
+    created_at           DateTime               @default(now())
+    updated_at           DateTime               @default(now())
+    view_count           Int                    @default(0)
+    like_count           Int                    @default(0)
     PortfolioLike        PortfolioLike[]
     PortfolioSkill       PortfolioSkill[]
     PortfolioProject     PortfolioProject[]
@@ -50,6 +55,7 @@ model PortfolioLike {
     user         User      @relation(fields: [user_id], references: [id])
     portfolio_id Int
     user_id      Int
+    created_at   DateTime  @default(now())
 }
 
 model PortfolioView {
@@ -59,6 +65,7 @@ model PortfolioView {
     portfolio_id Int
     user_id      Int
     source_ip    String
+    created_at   DateTime  @default(now())
 }
 
 model PortfolioSkill {
@@ -67,6 +74,7 @@ model PortfolioSkill {
     portfolio_id Int
     name         String
     level        Int
+    created_at   DateTime  @default(now())
 }
 
 model PortfolioProject {
@@ -75,6 +83,7 @@ model PortfolioProject {
     portfolio_id Int
     project_id   Int
     order        Int
+    created_at   DateTime  @default(now())
 }
 
 model PortfolioPrize {
@@ -84,6 +93,7 @@ model PortfolioPrize {
     name         String
     institution  String?
     prized_at    DateTime
+    created_at   DateTime  @default(now())
 }
 
 model PortfolioCertificate {
@@ -93,6 +103,7 @@ model PortfolioCertificate {
     name         String
     institution  String?
     certified_at DateTime
+    created_at   DateTime  @default(now())
 }
 
 model Project {
@@ -106,8 +117,10 @@ model Project {
     logo          String?         @db.Text
     start_at      DateTime?
     end_at        DateTime?
-    created_at    DateTime
-    updated_at    DateTime
+    view_count    Int             @default(0)
+    like_count    Int             @default(0)
+    created_at    DateTime        @default(now())
+    updated_at    DateTime        @default(now())
     ProjectSkill  ProjectSkill[]
     ProjectMember ProjectMember[]
     ProjectField  ProjectField[]
@@ -117,43 +130,48 @@ model Project {
 }
 
 model ProjectLike {
-    id         Int     @id @default(autoincrement())
-    project    Project @relation(fields: [project_id], references: [id])
-    user       User    @relation(fields: [user_id], references: [id])
+    id         Int      @id @default(autoincrement())
+    project    Project  @relation(fields: [project_id], references: [id])
+    user       User     @relation(fields: [user_id], references: [id])
     project_id Int
     user_id    Int
+    created_at DateTime @default(now())
 }
 
 model ProjectView {
-    id         Int     @id @default(autoincrement())
-    project    Project @relation(fields: [project_id], references: [id])
-    user       User    @relation(fields: [user_id], references: [id])
+    id         Int      @id @default(autoincrement())
+    project    Project  @relation(fields: [project_id], references: [id])
+    user       User     @relation(fields: [user_id], references: [id])
     project_id Int
     user_id    Int
     source_ip  String
+    created_at DateTime @default(now())
 }
 
 model ProjectSkill {
-    id         Int     @id @default(autoincrement())
-    project    Project @relation(fields: [project_id], references: [id])
+    id         Int      @id @default(autoincrement())
+    project    Project  @relation(fields: [project_id], references: [id])
     project_id Int
     name       String
+    created_at DateTime @default(now())
 }
 
 model ProjectMember {
-    id         Int     @id @default(autoincrement())
-    project    Project @relation(fields: [project_id], references: [id])
-    member     User    @relation(fields: [member_id], references: [id])
+    id         Int      @id @default(autoincrement())
+    project    Project  @relation(fields: [project_id], references: [id])
+    member     User     @relation(fields: [member_id], references: [id])
     project_id Int
     member_id  Int
     role       String
+    created_at DateTime @default(now())
 }
 
 model ProjectField {
-    id         Int     @id @default(autoincrement())
-    project    Project @relation(fields: [project_id], references: [id])
+    id         Int      @id @default(autoincrement())
+    project    Project  @relation(fields: [project_id], references: [id])
     project_id Int
     name       Field
+    created_at DateTime @default(now())
 }
 
 enum Field {
@@ -166,15 +184,17 @@ enum Field {
 }
 
 model ProjectImage {
-    id         Int     @id @default(autoincrement())
-    project    Project @relation(fields: [project_id], references: [id])
+    id         Int      @id @default(autoincrement())
+    project    Project  @relation(fields: [project_id], references: [id])
     project_id Int
-    link       String  @db.Text
+    link       String   @db.Text
     order      Int
+    created_at DateTime @default(now())
 }
 
 model EmailAuth {
-    id        Int    @id @default(autoincrement())
-    email     String
-    auth_code String
+    id         Int      @id @default(autoincrement())
+    email      String
+    auth_code  String
+    created_at DateTime @default(now())
 }


### PR DESCRIPTION
# 타임스탬프, 포트폴리오와 프로젝트의 조회수, 좋아요 카운트 추가
- 포트폴리오와 프로젝트 정렬시 조회수, 좋아요 순으로 정렬하기 위한 카운트를 저장할 칼럼 추가
- Elastic Stack 도입을 위한 created_at 칼럼 추가